### PR TITLE
Added importing service to docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+*.tar.bz2

--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ Then, you can build the image using docker-compose directly as follows:
 ```bash
 docker-compose up -d --build
 ```
+This will not only start the FHIR server, but also the `definition-importer` which will import standard codesystems listed in the FHIR spec into your FHIR server.
+The fhir server will be running on `http://localhost:8080`.
+When the `definition-importer` ends, you should be able to find a list of valuesets in the web browser. If the importer has failed, it will still be empty.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # capacity-hapi-fhir
+
+## How to build the definition-importer docker image
+First, download the 
+[hapi-fhir cli](https://github.com/hapifhir/hapi-fhir/releases/download/v5.3.0/hapi-fhir-5.3.0-cli.tar.bz2) from 
+github and place the archive in the subfolder `definition-importer`.
+
+Then, you can build the image using docker-compose directly as follows:
+```bash
+docker-compose up -d --build
+```

--- a/definition-importer/Dockerfile
+++ b/definition-importer/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:17-buster
+
+ENV FHIR_BASE=http://localhost:8080/fhir
+ARG TARGET_DIR=hapi-fhir-cli
+ARG HAPI_FHIR_CLI_ARCHIVE=hapi-fhir-5.3.0-cli.tar.bz2
+
+RUN mkdir /app /app/$TARGET_DIR
+COPY $HAPI_FHIR_CLI_ARCHIVE /app/$HAPI_FHIR_CLI_ARCHIVE
+
+WORKDIR /app
+RUN tar xjf $HAPI_FHIR_CLI_ARCHIVE -C $TARGET_DIR
+
+WORKDIR /app/$TARGET_DIR
+CMD ./hapi-fhir-cli upload-definitions -t $FHIR_BASE -v r4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,9 @@ services:
     image: "hapiproject/hapi:latest"
     ports:
       - "8080:8080"
+  definition-importer:
+    depends_on:
+      - hapi
+    build: definition-importer/
+    environment:
+      - FHIR_BASE=http://hapi:8080/fhir


### PR DESCRIPTION
The additional service runs the hapi-fhir cli and automatically downloads the standard definitions from the FHIR spec website.